### PR TITLE
fix(router): route by `type` property, not message key

### DIFF
--- a/coinbase-websocket-feed-router/src/main/java/io/streamnative/data/feeds/realtime/coinbase/WebsocketFeedRouter.java
+++ b/coinbase-websocket-feed-router/src/main/java/io/streamnative/data/feeds/realtime/coinbase/WebsocketFeedRouter.java
@@ -21,7 +21,14 @@ public class WebsocketFeedRouter implements Function<String, Void> {
 
     @Override
     public Void process(String jsonString, Context ctx) throws Exception {
-        String feedName = ctx.getCurrentRecord().getKey().orElse("UNKNOWN");
+        // coinbase-live-feed (the upstream source) emits the channel name as a Pulsar
+        // message property `type` (e.g. "ticker", "auction", "rfq_match"), not as the
+        // message key. Prefer the property; fall back to the key for producers that
+        // happen to set it that way.
+        Map<String, String> props = ctx.getCurrentRecord().getProperties();
+        String feedName = (props != null && props.get("type") != null)
+                ? props.get("type")
+                : ctx.getCurrentRecord().getKey().orElse("UNKNOWN");
 
         try {
             String destTopic = this.topicMap.get(feedName);

--- a/coinbase-websocket-feed-router/src/test/java/io/streamnative/data/feeds/realtime/coinbase/WebsocketFeedRouterTests.java
+++ b/coinbase-websocket-feed-router/src/test/java/io/streamnative/data/feeds/realtime/coinbase/WebsocketFeedRouterTests.java
@@ -10,6 +10,7 @@ import org.mockito.Mock;
 import org.slf4j.Logger;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -29,6 +30,7 @@ public class WebsocketFeedRouterTests {
 
     static {
         TOPIC_MAP.put("rfq_match", "persistent://feeds/realtime/rfq-match");
+        TOPIC_MAP.put("ticker", "persistent://feeds/realtime/ticker");
     }
 
     @Test
@@ -64,6 +66,44 @@ public class WebsocketFeedRouterTests {
         // Key is the base symbol — "BTC" extracted from "BTC-USD".
         verify(mockMessageBuilder).key("BTC");
         // Body is the original jsonString unchanged.
+        verify(mockMessageBuilder).value(json);
+        verify(mockMessageBuilder).send();
+    }
+
+    @Test
+    public void tickerByPropertyTest() throws Exception {
+        // coinbase-live-feed publishes the channel as a Pulsar message property `type`
+        // (not the message key). Verify the router picks the destination from the
+        // property and emits the symbol-keyed output.
+        String json = "{\"sequence\":1281102714,\"product_id\":\"ETH-USD\",\"price\":\"3500.00\",\"open_24h\":\"3400.00\",\"volume_24h\":\"100\",\"low_24h\":\"3399\",\"high_24h\":\"3501\",\"volume_30d\":\"200\",\"best_bid\":\"3500\",\"best_bid_size\":\"1\",\"best_ask\":\"3500.01\",\"best_ask_size\":\"1\",\"side\":\"buy\",\"time\":\"2026-05-14T00:23:58.558245Z\",\"trade_id\":1017793859,\"last_size\":\"0.004\"}";
+
+        mockContext = mock(Context.class);
+        mockRecord = mock(Record.class);
+        Logger mockLogger = mock(Logger.class);
+        TypedMessageBuilder mockMessageBuilder = mock(TypedMessageBuilder.class);
+        MessageId mockMessageId = mock(MessageId.class);
+
+        Map<String, String> props = new HashMap<>();
+        props.put("type", "ticker");
+
+        when(mockContext.getCurrentRecord()).thenReturn(mockRecord);
+        when(mockContext.getLogger()).thenReturn(mockLogger);
+        when(mockContext.getUserConfigValue(anyString())).thenReturn(Optional.of(TOPIC_MAP));
+        when(mockContext.newOutputMessage(anyString(),
+                any(Schema.class))).thenReturn(mockMessageBuilder);
+
+        when(mockMessageBuilder.key(anyString())).thenReturn(mockMessageBuilder);
+        when(mockMessageBuilder.value(anyString())).thenReturn(mockMessageBuilder);
+        when(mockMessageBuilder.send()).thenReturn(mockMessageId);
+        // No key set on the incoming record — only the `type` property carries the channel.
+        when(mockRecord.getKey()).thenReturn(Optional.empty());
+        when(mockRecord.getProperties()).thenReturn(props);
+
+        router.initialize(mockContext);
+        router.process(json, mockContext);
+
+        verify(mockContext).newOutputMessage("persistent://feeds/realtime/ticker", Schema.STRING);
+        verify(mockMessageBuilder).key("ETH");
         verify(mockMessageBuilder).value(json);
         verify(mockMessageBuilder).send();
     }


### PR DESCRIPTION
## Summary

- Router was looking up `TopicMap` by `ctx.getCurrentRecord().getKey()`, but coinbase-live-feed publishes the channel name as a Pulsar message **property** `type` (`ticker`, `auction`, `rfq_match`), not as the message key.
- Every record fell through the "unmapped → drop" path while still counting as `processedSuccessfully`. Symptom: in tradewise-demo the router showed ~7800 successfully processed, but `coinbase-ticker-feed-kafka` had **zero** new messages — and the downstream broker-side selector-filter had nothing to filter.
- This patch reads the `type` property first; falls back to the message key for producers that do set it that way (e.g. existing tests / Kafka-keyed sources).

## Diagnosis

`peek-messages` on `persistent://tradewise/live-market-data/coinbase-ticker-feed`:

```
Batch Message ID: 86:1:0
Properties:
  X-Pulsar-batch-size    1271
  X-Pulsar-num-batch-message    3
  type    ticker
{"sequence":11125116188,"product_id":"DOT-USD",...}
```

No `Key:` line on any message. `WebsocketFeedRouter.java:24` reads:

```java
String feedName = ctx.getCurrentRecord().getKey().orElse("UNKNOWN");
```

`feedName="UNKNOWN"` → `topicMap.get("UNKNOWN")=null` → silent drop at line 30.

## Fix

```java
Map<String, String> props = ctx.getCurrentRecord().getProperties();
String feedName = (props != null && props.get("type") != null)
        ? props.get("type")
        : ctx.getCurrentRecord().getKey().orElse("UNKNOWN");
```

## Test plan

- [x] New `tickerByPropertyTest`: `getProperties` returns `{type: ticker}`, `getKey` returns `Optional.empty`. Verifies the message routes to the ticker destination with `key=ETH` (base symbol from `ETH-USD`).
- [x] Existing `rfqMatchTest` unchanged — it stubs `getKey()` only and leaves `getProperties()` unstubbed (Mockito returns null), so the fallback path takes over and the rfq routing still works.
- [x] `mvn -pl coinbase-websocket-feed-router clean package` → BUILD SUCCESS, `Tests run: 2, Failures: 0`.
- [ ] Post-tag: redeploy in tradewise-demo via `COINBASE_FN_REL=v1.0.3 ./infra/terraform/recreate.sh`; verify peek on `coinbase-ticker-feed-kafka-partition-0` shows `key: BTC` (or ETH/SOL) and filtered topic `msgInCounter` climbs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)