### PR TITLE
feat(connect): add Coinbase Kafka Connect source plugin

### DIFF
--- a/.github/workflows/release-nars.yml
+++ b/.github/workflows/release-nars.yml
@@ -1,9 +1,10 @@
-name: Release NARs
+name: Release artifacts
 
-# On every v* tag, builds the three function NARs (coinbase-live-feed,
-# coinbase-websocket-feed-router, coinbase-volatility-tracker) and attaches them to the
+# On every v* tag, builds the three Pulsar function NARs (coinbase-live-feed,
+# coinbase-websocket-feed-router, coinbase-volatility-tracker) AND the Kafka Connect
+# source plugin jar (coinbase-kafka-connect-source) and attaches them to the
 # corresponding GitHub Release. Consumer deploy scripts (e.g. Trade-Wise-app's
-# recreate.sh) curl them by URL.
+# recreate.sh and the Kafka Connect install-plugin.sh) curl them by URL.
 
 on:
   push:
@@ -12,7 +13,7 @@ on:
 
 jobs:
   release:
-    name: Build NARs and attach to release
+    name: Build artifacts and attach to release
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -31,20 +32,27 @@ jobs:
           VERSION="${GITHUB_REF_NAME#v}"
           mvn -B versions:set -DnewVersion="${VERSION}" -DgenerateBackupPoms=false
 
-      - name: Build NARs
+      - name: Build artifacts
         run: mvn -B -DskipTests package
 
-      - name: Stage NAR files
+      - name: Stage release files
         run: |
           mkdir -p staging
           cp coinbase-live-feed/target/coinbase-live-feed-*.nar staging/
           cp coinbase-websocket-feed-router/target/coinbase-websocket-feed-router-*.nar staging/
           cp coinbase-volatility-tracker/target/coinbase-volatility-tracker-*.nar staging/
+          # Kafka Connect plugin is a plain (shaded) jar, not a NAR. The shade plugin
+          # produces target/<artifact>-<version>.jar after replacing the original;
+          # exclude the "original-" pre-shade jar.
+          cp coinbase-kafka-connect-source/target/coinbase-kafka-connect-source-*.jar staging/
+          rm -f staging/original-coinbase-kafka-connect-source-*.jar
           ls -la staging/
 
-      - name: Create release + attach NARs
+      - name: Create release + attach artifacts
         uses: softprops/action-gh-release@v2
         with:
-          files: staging/*.nar
+          files: |
+            staging/*.nar
+            staging/*.jar
           generate_release_notes: true
           fail_on_unmatched_files: true

--- a/coinbase-kafka-connect-source/pom.xml
+++ b/coinbase-kafka-connect-source/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.streamnative.data.feeds.realtime</groupId>
+        <artifactId>coinbase-functions</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>coinbase-kafka-connect-source</artifactId>
+    <name>Coinbase Functions :: Kafka Connect Source</name>
+    <packaging>jar</packaging>
+
+    <properties>
+        <kafka.version>3.7.0</kafka.version>
+        <jackson.version>2.16.1</jackson.version>
+    </properties>
+
+    <dependencies>
+        <!-- Kafka Connect framework — provided by the Connect worker at runtime. -->
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-api</artifactId>
+            <version>${kafka.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Jackson for JSON parsing. Bundled into the plugin uber-jar. -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <!-- Test scope -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!--
+              The parent pom wires nifi-nar-maven-plugin into the package phase for every
+              child module. Kafka Connect plugins are plain JARs, not NARs — disable the
+              nar execution here so the build emits only the shaded jar.
+            -->
+            <plugin>
+                <groupId>org.apache.nifi</groupId>
+                <artifactId>nifi-nar-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-nar</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!--
+              Shade Jackson (and any other non-Connect deps) into the plugin jar so it
+              drops cleanly into Kafka Connect's plugin.path. Explicitly EXCLUDE:
+                - The Connect framework (provided by the worker)
+                - kafka-clients (provided by the worker)
+                - Pulsar deps inherited from the parent pom (no Pulsar at runtime here)
+                - slf4j-api (Connect provides logging)
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals><goal>shade</goal></goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>org.apache.kafka:*</exclude>
+                                    <exclude>org.apache.pulsar:*</exclude>
+                                    <exclude>io.streamnative:*</exclude>
+                                    <exclude>io.netty:*</exclude>
+                                    <exclude>org.slf4j:*</exclude>
+                                </excludes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/coinbase-kafka-connect-source/src/main/java/io/streamnative/data/feeds/realtime/coinbase/connect/CoinbaseConnectorConfig.java
+++ b/coinbase-kafka-connect-source/src/main/java/io/streamnative/data/feeds/realtime/coinbase/connect/CoinbaseConnectorConfig.java
@@ -1,0 +1,41 @@
+package io.streamnative.data.feeds.realtime.coinbase.connect;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.Type;
+
+public class CoinbaseConnectorConfig extends AbstractConfig {
+
+    public static final String COINBASE_WS_URL = "coinbase.ws.url";
+    public static final String COINBASE_CHANNELS = "coinbase.channels";
+    public static final String COINBASE_PRODUCTS = "coinbase.products";
+    public static final String KAFKA_TOPIC = "kafka.topic";
+    public static final String POLL_TIMEOUT_MS = "poll.timeout.ms";
+
+    public static final ConfigDef CONFIG_DEF = new ConfigDef()
+        .define(COINBASE_WS_URL, Type.STRING, "wss://ws-feed.exchange.coinbase.com",
+            Importance.HIGH, "Coinbase WebSocket feed URL")
+        .define(COINBASE_CHANNELS, Type.LIST, List.of("ticker"),
+            Importance.HIGH, "Coinbase channels to subscribe to (ticker, auction, rfq_match)")
+        .define(COINBASE_PRODUCTS, Type.LIST,
+            List.of("BTC-USD","ETH-USD","SOL-USD","DOT-USD","XRP-USD","ADA-USD"),
+            Importance.HIGH, "Coinbase product_ids to subscribe to")
+        .define(KAFKA_TOPIC, Type.STRING, "coinbase-ticker-feed-kafka",
+            Importance.HIGH, "Output Kafka topic — must match the topic the broker-side selector-filter consumes from")
+        .define(POLL_TIMEOUT_MS, Type.LONG, 200L,
+            Importance.LOW, "Maximum time poll() waits for new records before returning an empty batch");
+
+    public CoinbaseConnectorConfig(Map<String, String> originals) {
+        super(CONFIG_DEF, originals);
+    }
+
+    public String wsUrl() { return getString(COINBASE_WS_URL); }
+    public List<String> channels() { return getList(COINBASE_CHANNELS); }
+    public List<String> products() { return getList(COINBASE_PRODUCTS); }
+    public String kafkaTopic() { return getString(KAFKA_TOPIC); }
+    public long pollTimeoutMs() { return getLong(POLL_TIMEOUT_MS); }
+}

--- a/coinbase-kafka-connect-source/src/main/java/io/streamnative/data/feeds/realtime/coinbase/connect/CoinbaseSourceConnector.java
+++ b/coinbase-kafka-connect-source/src/main/java/io/streamnative/data/feeds/realtime/coinbase/connect/CoinbaseSourceConnector.java
@@ -1,0 +1,53 @@
+package io.streamnative.data.feeds.realtime.coinbase.connect;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.Task;
+import org.apache.kafka.connect.source.SourceConnector;
+
+public class CoinbaseSourceConnector extends SourceConnector {
+
+    private Map<String, String> props;
+
+    @Override
+    public String version() {
+        return "1.1.0";
+    }
+
+    @Override
+    public void start(Map<String, String> props) {
+        this.props = props;
+        // Validate config eagerly so misconfiguration fails at Connect REST POST time
+        // rather than later in task start.
+        new CoinbaseConnectorConfig(props);
+    }
+
+    @Override
+    public Class<? extends Task> taskClass() {
+        return CoinbaseSourceTask.class;
+    }
+
+    @Override
+    public List<Map<String, String>> taskConfigs(int maxTasks) {
+        // Coinbase WebSocket is one socket per process. Running more than one task
+        // would open duplicate sockets and emit each record N times — pin to a single
+        // task regardless of what the worker requested.
+        List<Map<String, String>> taskConfigs = new ArrayList<>(1);
+        taskConfigs.add(new HashMap<>(props));
+        return taskConfigs;
+    }
+
+    @Override
+    public void stop() {
+        // No connector-level resources — task owns the WebSocket lifecycle.
+    }
+
+    @Override
+    public ConfigDef config() {
+        return CoinbaseConnectorConfig.CONFIG_DEF;
+    }
+}

--- a/coinbase-kafka-connect-source/src/main/java/io/streamnative/data/feeds/realtime/coinbase/connect/CoinbaseSourceTask.java
+++ b/coinbase-kafka-connect-source/src/main/java/io/streamnative/data/feeds/realtime/coinbase/connect/CoinbaseSourceTask.java
@@ -1,0 +1,183 @@
+package io.streamnative.data.feeds.realtime.coinbase.connect;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.source.SourceTask;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CoinbaseSourceTask extends SourceTask {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CoinbaseSourceTask.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** Drops frames if the worker stalls — at 40 msg/s and a 200ms poll interval the
+     *  steady-state backlog is ~8 records, so 10k headroom is generous. */
+    private static final int QUEUE_CAPACITY = 10_000;
+
+    private CoinbaseConnectorConfig config;
+    private LinkedBlockingQueue<String> queue;
+    private WebSocket ws;
+    private HttpClient httpClient;
+    /** Accumulates partial text frames — Coinbase emits batched JSON occasionally. */
+    private final StringBuilder partial = new StringBuilder();
+
+    @Override
+    public String version() {
+        return "1.1.0";
+    }
+
+    @Override
+    public void start(Map<String, String> props) {
+        this.config = new CoinbaseConnectorConfig(props);
+        this.queue = new LinkedBlockingQueue<>(QUEUE_CAPACITY);
+        this.httpClient = HttpClient.newHttpClient();
+        connectWebSocket();
+    }
+
+    private void connectWebSocket() {
+        String subscribe = buildSubscribeMessage(config.channels(), config.products());
+        LOG.info("Connecting to Coinbase WS at {} with subscribe={}", config.wsUrl(), subscribe);
+
+        CompletableFuture<WebSocket> wsFuture = httpClient.newWebSocketBuilder()
+            .buildAsync(URI.create(config.wsUrl()), new WebSocket.Listener() {
+                @Override
+                public void onOpen(WebSocket webSocket) {
+                    webSocket.sendText(subscribe, true);
+                    webSocket.request(1);
+                }
+
+                @Override
+                public CompletionStage<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+                    partial.append(data);
+                    if (last) {
+                        String frame = partial.toString();
+                        partial.setLength(0);
+                        if (!queue.offer(frame)) {
+                            LOG.warn("WS queue full ({} cap); dropping frame: {}",
+                                QUEUE_CAPACITY, frame.length() > 80 ? frame.substring(0, 80) + "…" : frame);
+                        }
+                    }
+                    webSocket.request(1);
+                    return null;
+                }
+
+                @Override
+                public void onError(WebSocket webSocket, Throwable error) {
+                    LOG.error("Coinbase WS error", error);
+                }
+            });
+
+        this.ws = wsFuture.join();
+    }
+
+    /** Build the Coinbase WS subscribe JSON message. Mirrors what coinbase-live-feed sends. */
+    static String buildSubscribeMessage(List<String> channels, List<String> products) {
+        Map<String, Object> msg = new HashMap<>();
+        msg.put("type", "subscribe");
+        msg.put("product_ids", products);
+        msg.put("channels", channels);
+        try {
+            return MAPPER.writeValueAsString(msg);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize subscribe message", e);
+        }
+    }
+
+    @Override
+    public List<SourceRecord> poll() throws InterruptedException {
+        List<SourceRecord> batch = new ArrayList<>();
+
+        // Block briefly for the first frame so we don't busy-spin when the WS is idle…
+        String first = queue.poll(config.pollTimeoutMs(), TimeUnit.MILLISECONDS);
+        if (first == null) {
+            return batch;
+        }
+        toRecord(first).ifPresent(batch::add);
+
+        // …then drain whatever else is buffered without blocking.
+        String next;
+        while ((next = queue.poll()) != null) {
+            toRecord(next).ifPresent(batch::add);
+        }
+        return batch;
+    }
+
+    /**
+     * Translate one Coinbase JSON frame into a Kafka {@link SourceRecord}. Drops frames
+     * whose {@code type} isn't in the configured channel list (Coinbase mixes
+     * subscriptions, heartbeats, and channel data on one socket), and frames missing
+     * a {@code product_id} (heartbeats, subscription acks).
+     */
+    java.util.Optional<SourceRecord> toRecord(String json) {
+        try {
+            JsonNode root = MAPPER.readTree(json);
+            String type = root.path("type").asText("");
+            if (!config.channels().contains(type)) {
+                LOG.debug("Skipping non-data frame type=[{}]", type);
+                return java.util.Optional.empty();
+            }
+            String productId = root.path("product_id").asText(null);
+            if (productId == null || productId.isEmpty()) {
+                return java.util.Optional.empty();
+            }
+            String key = baseSymbol(productId);
+
+            ConnectHeaders headers = new ConnectHeaders();
+            headers.addString("type", type);
+
+            return java.util.Optional.of(new SourceRecord(
+                /* sourcePartition */ Map.of("ws", config.wsUrl()),
+                /* sourceOffset    */ Map.of("seq", root.path("sequence").asLong(System.currentTimeMillis())),
+                /* topic           */ config.kafkaTopic(),
+                /* partition       */ null,
+                /* keySchema       */ Schema.STRING_SCHEMA,
+                /* key             */ key,
+                /* valueSchema     */ Schema.STRING_SCHEMA,
+                /* value           */ json,
+                /* timestamp       */ null,
+                /* headers         */ headers
+            ));
+        } catch (Exception e) {
+            LOG.warn("Failed to parse Coinbase frame; dropping: {}", e.getMessage());
+            return java.util.Optional.empty();
+        }
+    }
+
+    /** Coinbase product_ids are BASE-QUOTE pairs (BTC-USD → BTC). Mirrors
+     *  {@code WebsocketFeedRouter.baseSymbol} so downstream selectors that read keys
+     *  emitted by either ingestion path see identical values. */
+    static String baseSymbol(String productId) {
+        if (productId == null || productId.isEmpty()) {
+            return "UNKNOWN";
+        }
+        int dash = productId.indexOf('-');
+        return dash < 0 ? productId : productId.substring(0, dash);
+    }
+
+    @Override
+    public void stop() {
+        if (ws != null) {
+            try {
+                ws.sendClose(WebSocket.NORMAL_CLOSURE, "task stop");
+            } catch (Exception e) {
+                LOG.warn("Error closing WebSocket on stop", e);
+            }
+        }
+    }
+}

--- a/coinbase-kafka-connect-source/src/test/java/io/streamnative/data/feeds/realtime/coinbase/connect/CoinbaseSourceTaskTest.java
+++ b/coinbase-kafka-connect-source/src/test/java/io/streamnative/data/feeds/realtime/coinbase/connect/CoinbaseSourceTaskTest.java
@@ -1,0 +1,98 @@
+package io.streamnative.data.feeds.realtime.coinbase.connect;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class CoinbaseSourceTaskTest {
+
+    private CoinbaseSourceTask task;
+
+    @Before
+    public void setUp() {
+        // Use a private start path that wires config without actually opening the WS.
+        // start() in production opens the socket; for unit tests we just need config.
+        task = new CoinbaseSourceTask() {
+            @Override
+            public void start(Map<String, String> props) {
+                try {
+                    java.lang.reflect.Field cfgField = CoinbaseSourceTask.class.getDeclaredField("config");
+                    cfgField.setAccessible(true);
+                    cfgField.set(this, new CoinbaseConnectorConfig(props));
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        task.start(Map.of(
+            CoinbaseConnectorConfig.KAFKA_TOPIC, "coinbase-ticker-feed-kafka",
+            CoinbaseConnectorConfig.COINBASE_CHANNELS, "ticker",
+            CoinbaseConnectorConfig.COINBASE_PRODUCTS, "BTC-USD,ETH-USD"
+        ));
+    }
+
+    @Test
+    public void tickerFrameProducesKeyedRecord() {
+        String json = "{\"type\":\"ticker\",\"sequence\":12345,\"product_id\":\"BTC-USD\","
+                    + "\"price\":\"79462.23\",\"time\":\"2026-05-14T00:00:00Z\"}";
+
+        Optional<SourceRecord> rec = task.toRecord(json);
+        assertTrue("ticker frame should produce a record", rec.isPresent());
+
+        SourceRecord r = rec.get();
+        assertEquals("coinbase-ticker-feed-kafka", r.topic());
+        assertEquals(Schema.STRING_SCHEMA, r.keySchema());
+        // Base symbol — BTC-USD → BTC. Must match WebsocketFeedRouter.baseSymbol() so
+        // downstream selectors see identical keys regardless of ingestion path.
+        assertEquals("BTC", r.key());
+        // Value is the raw JSON forwarded verbatim.
+        assertEquals(json, r.value());
+        // type=ticker header for parity with the Pulsar router output.
+        assertNotNull(r.headers().lastWithName("type"));
+        assertEquals("ticker", r.headers().lastWithName("type").value());
+    }
+
+    @Test
+    public void heartbeatFrameIsDropped() {
+        // Coinbase emits heartbeats on the same socket. type != "ticker" → drop.
+        String json = "{\"type\":\"heartbeat\",\"sequence\":1,\"product_id\":\"BTC-USD\"}";
+        Optional<SourceRecord> rec = task.toRecord(json);
+        assertFalse(rec.isPresent());
+    }
+
+    @Test
+    public void frameWithoutProductIdIsDropped() {
+        // Subscriptions ack messages have type=subscriptions but no product_id.
+        String json = "{\"type\":\"subscriptions\",\"channels\":[]}";
+        Optional<SourceRecord> rec = task.toRecord(json);
+        assertFalse(rec.isPresent());
+    }
+
+    @Test
+    public void baseSymbolHandlesEdgeCases() {
+        assertEquals("BTC",     CoinbaseSourceTask.baseSymbol("BTC-USD"));
+        assertEquals("ETH",     CoinbaseSourceTask.baseSymbol("ETH-EUR"));
+        assertEquals("NOPAIR",  CoinbaseSourceTask.baseSymbol("NOPAIR"));
+        assertEquals("UNKNOWN", CoinbaseSourceTask.baseSymbol(null));
+        assertEquals("UNKNOWN", CoinbaseSourceTask.baseSymbol(""));
+    }
+
+    @Test
+    public void subscribeMessageSerializes() {
+        String msg = CoinbaseSourceTask.buildSubscribeMessage(
+            List.of("ticker"), List.of("BTC-USD", "ETH-USD"));
+        assertTrue(msg.contains("\"type\":\"subscribe\""));
+        assertTrue(msg.contains("\"channels\":[\"ticker\"]"));
+        assertTrue(msg.contains("\"product_ids\":[\"BTC-USD\",\"ETH-USD\"]"));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <module>coinbase-live-feed</module>
         <module>coinbase-websocket-feed-router</module>
         <module>coinbase-volatility-tracker</module>
+        <module>coinbase-kafka-connect-source</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
## Summary

New `coinbase-kafka-connect-source` sibling module — a Kafka Connect Source plugin that produces the same shape of records to `coinbase-ticker-feed-kafka` as the existing Pulsar-based `coinbase-live-feed` + `coinbase-websocket-feed-router` pair. The broker-side selector-filter downstream sees identical keyed input regardless of which ingestion path is deployed, so the rest of the demo (orchestrator, filtered topics, watchlist UI) is unchanged.

This is **Workstream 1** of the multi-repo plan to add a fully Kafka-native demo path. The plugin JAR is portable across any Kafka Connect worker — Workstream 2 (Trade-Wise-app `INGESTION_MODE` flag, connector deploy via `snctl` against SN Cloud's managed Kafka Connect runtime) is gated on this PR being tagged + released.

## Module shape

| Class | Role |
| --- | --- |
| `CoinbaseConnectorConfig` | `ConfigDef` with `coinbase.ws.url`, `coinbase.channels`, `coinbase.products`, `kafka.topic`, `poll.timeout.ms` |
| `CoinbaseSourceConnector` | Pins to a single task (Coinbase WS is one socket per process; parallel tasks would emit duplicates) |
| `CoinbaseSourceTask` | `java.net.http.WebSocket` consumer → bounded `LinkedBlockingQueue` → `poll()` drains, parses, filters by channel, emits `SourceRecord(key=baseSymbol(product_id), value=raw JSON, headers.type=channel)` |

## Output shape parity with the Pulsar router

| Field | This connector | `coinbase-websocket-feed-router` v1.0.3 |
| --- | --- | --- |
| Output topic | `coinbase-ticker-feed-kafka` (configurable) | `coinbase-ticker-feed-kafka` |
| Key | `baseSymbol(product_id)` → `BTC` from `BTC-USD` | same |
| Value | raw Coinbase JSON, verbatim | same (forwarded `Schema.STRING`) |
| `type` channel hint | Kafka header | Pulsar message property |

The selector-filter matches on `__key__ IN ('BTC',...)` so the hint location doesn't matter for the demo; it's included for parity / debuggability.

## Packaging notes

- Disabled the parent pom's `nifi-nar-maven-plugin` execution for this module — Kafka Connect plugins must be plain shaded jars on the worker's `plugin.path`, not NARs.
- `maven-shade-plugin` bundles Jackson; excludes the inherited Pulsar + Netty + slf4j deps and the `kafka-clients` / `connect-api` deps that Connect already provides at runtime.
- Uses `java.net.http.WebSocket` (JDK 11+) so there's no tyrus / jakarta WebSocket dep to drag along.

## CI

`release-nars.yml` renamed to "Release artifacts" and extended to stage `coinbase-kafka-connect-source-<v>.jar` alongside the existing three NARs on every `v*` tag. The "original-" pre-shade jar is filtered out so only the shaded plugin jar ships.

## Test plan

- [x] `mvn -pl coinbase-kafka-connect-source clean package` → BUILD SUCCESS, `Tests run: 5, Failures: 0`.
- [x] Tests cover: keyed-record emission, heartbeat drop, missing-product_id drop, `baseSymbol` edge cases, subscribe-message serialization.
- [ ] After merge → tag `v1.1.0` → confirm release attaches the four artifacts (3 NARs + 1 JAR).
- [ ] Workstream 2 — deploy plugin to a Kafka Connect worker pointed at SN Cloud KoP, confirm `coinbase-ticker-feed-kafka` receives keyed records at ~40 msg/s identical to the Pulsar router path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
