### PR TITLE
fix(connector): WS reconnect with exponential backoff

### DIFF
--- a/coinbase-kafka-connect-source/src/main/java/io/streamnative/data/feeds/realtime/coinbase/connect/CoinbaseSourceTask.java
+++ b/coinbase-kafka-connect-source/src/main/java/io/streamnative/data/feeds/realtime/coinbase/connect/CoinbaseSourceTask.java
@@ -9,8 +9,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -32,14 +38,28 @@ public class CoinbaseSourceTask extends SourceTask {
 
     private CoinbaseConnectorConfig config;
     private LinkedBlockingQueue<String> queue;
-    private WebSocket ws;
+    private final AtomicReference<WebSocket> ws = new AtomicReference<>();
     private HttpClient httpClient;
     /** Accumulates partial text frames — Coinbase emits batched JSON occasionally. */
     private final StringBuilder partial = new StringBuilder();
 
+    // Reconnect machinery. Coinbase's public WS sends a heartbeat every ~15s when idle but
+    // periodically closes connections that have been up for >24h (or transient network
+    // hiccups close them sooner). Kafka Connect's framework can't see this — the SourceTask
+    // stays "RUNNING" while poll() just stops returning records. We watch onClose/onError
+    // ourselves and schedule a reconnect with exponential backoff + jitter.
+    private final AtomicBoolean stopped = new AtomicBoolean(false);
+    private final AtomicBoolean reconnectScheduled = new AtomicBoolean(false);
+    private final AtomicInteger reconnectAttempts = new AtomicInteger(0);
+    private ScheduledExecutorService reconnectExecutor;
+
+    /** Backoff schedule: 1s, 2s, 4s, 8s, 16s, then capped at 30s. Adds up to 25% jitter. */
+    private static final long INITIAL_BACKOFF_MS = 1_000;
+    private static final long MAX_BACKOFF_MS = 30_000;
+
     @Override
     public String version() {
-        return "1.1.0";
+        return "1.1.1";
     }
 
     @Override
@@ -47,17 +67,29 @@ public class CoinbaseSourceTask extends SourceTask {
         this.config = new CoinbaseConnectorConfig(props);
         this.queue = new LinkedBlockingQueue<>(QUEUE_CAPACITY);
         this.httpClient = HttpClient.newHttpClient();
+        this.reconnectExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "coinbase-ws-reconnect");
+            t.setDaemon(true);
+            return t;
+        });
         connectWebSocket();
     }
 
     private void connectWebSocket() {
+        if (stopped.get()) {
+            return;
+        }
         String subscribe = buildSubscribeMessage(config.channels(), config.products());
-        LOG.info("Connecting to Coinbase WS at {} with subscribe={}", config.wsUrl(), subscribe);
+        LOG.info("Connecting to Coinbase WS at {} (attempt {})", config.wsUrl(), reconnectAttempts.get() + 1);
 
         CompletableFuture<WebSocket> wsFuture = httpClient.newWebSocketBuilder()
             .buildAsync(URI.create(config.wsUrl()), new WebSocket.Listener() {
                 @Override
                 public void onOpen(WebSocket webSocket) {
+                    LOG.info("Coinbase WS open; sending subscribe");
+                    // Reset backoff on successful open so a long-lived connection that
+                    // eventually drops gets a fast first retry instead of a long wait.
+                    reconnectAttempts.set(0);
                     webSocket.sendText(subscribe, true);
                     webSocket.request(1);
                 }
@@ -78,12 +110,53 @@ public class CoinbaseSourceTask extends SourceTask {
                 }
 
                 @Override
+                public CompletionStage<?> onClose(WebSocket webSocket, int statusCode, String reason) {
+                    LOG.warn("Coinbase WS closed (status={}, reason='{}'); scheduling reconnect",
+                        statusCode, reason == null ? "" : reason);
+                    scheduleReconnect();
+                    return null;
+                }
+
+                @Override
                 public void onError(WebSocket webSocket, Throwable error) {
-                    LOG.error("Coinbase WS error", error);
+                    LOG.error("Coinbase WS error; scheduling reconnect", error);
+                    scheduleReconnect();
                 }
             });
 
-        this.ws = wsFuture.join();
+        // buildAsync itself can fail (DNS, TLS, refused) — don't block forever waiting
+        // for join() to throw; let exceptionally feed back into the retry loop.
+        wsFuture.whenComplete((webSocket, throwable) -> {
+            if (throwable != null) {
+                LOG.error("Coinbase WS buildAsync failed; scheduling reconnect", throwable);
+                scheduleReconnect();
+            } else {
+                ws.set(webSocket);
+            }
+        });
+    }
+
+    /**
+     * Schedule a single reconnect with exponential backoff + jitter. Idempotent: if a
+     * reconnect is already queued, returns silently (avoids piling up attempts when
+     * both onClose AND onError fire for the same drop). After stop(), short-circuits.
+     */
+    void scheduleReconnect() {
+        if (stopped.get()) {
+            return;
+        }
+        if (!reconnectScheduled.compareAndSet(false, true)) {
+            return;
+        }
+        int attempt = reconnectAttempts.incrementAndGet();
+        long base = Math.min(INITIAL_BACKOFF_MS * (1L << Math.min(attempt - 1, 5)), MAX_BACKOFF_MS);
+        long jitter = ThreadLocalRandom.current().nextLong(0, Math.max(1, base / 4));
+        long delayMs = base + jitter;
+        LOG.info("Coinbase WS reconnect attempt {} in {}ms", attempt, delayMs);
+        reconnectExecutor.schedule(() -> {
+            reconnectScheduled.set(false);
+            connectWebSocket();
+        }, delayMs, TimeUnit.MILLISECONDS);
     }
 
     /** Build the Coinbase WS subscribe JSON message. Mirrors what coinbase-live-feed sends. */
@@ -172,9 +245,16 @@ public class CoinbaseSourceTask extends SourceTask {
 
     @Override
     public void stop() {
-        if (ws != null) {
+        // Flip the stopped flag FIRST so any in-flight onClose/onError listeners
+        // that fire while we're tearing down don't schedule another reconnect.
+        stopped.set(true);
+        if (reconnectExecutor != null) {
+            reconnectExecutor.shutdownNow();
+        }
+        WebSocket current = ws.getAndSet(null);
+        if (current != null) {
             try {
-                ws.sendClose(WebSocket.NORMAL_CLOSURE, "task stop");
+                current.sendClose(WebSocket.NORMAL_CLOSURE, "task stop");
             } catch (Exception e) {
                 LOG.warn("Error closing WebSocket on stop", e);
             }

--- a/coinbase-kafka-connect-source/src/test/java/io/streamnative/data/feeds/realtime/coinbase/connect/CoinbaseSourceTaskTest.java
+++ b/coinbase-kafka-connect-source/src/test/java/io/streamnative/data/feeds/realtime/coinbase/connect/CoinbaseSourceTaskTest.java
@@ -95,4 +95,32 @@ public class CoinbaseSourceTaskTest {
         assertTrue(msg.contains("\"channels\":[\"ticker\"]"));
         assertTrue(msg.contains("\"product_ids\":[\"BTC-USD\",\"ETH-USD\"]"));
     }
+
+    /**
+     * After {@link CoinbaseSourceTask#stop()}, any in-flight onClose/onError listener that
+     * fires while teardown is racing must NOT schedule another reconnect. The stopped flag
+     * gates {@code scheduleReconnect} as a short-circuit before touching the executor (which
+     * has been shut down).
+     */
+    @Test
+    public void scheduleReconnectIsNoOpAfterStop() throws Exception {
+        // Real task this time — we need the scheduledExecutorService field initialized.
+        CoinbaseSourceTask realTask = new CoinbaseSourceTask();
+        java.lang.reflect.Field cfg = CoinbaseSourceTask.class.getDeclaredField("config");
+        cfg.setAccessible(true);
+        cfg.set(realTask, new CoinbaseConnectorConfig(Map.of(
+            CoinbaseConnectorConfig.KAFKA_TOPIC, "any",
+            CoinbaseConnectorConfig.COINBASE_CHANNELS, "ticker",
+            CoinbaseConnectorConfig.COINBASE_PRODUCTS, "BTC-USD"
+        )));
+        java.lang.reflect.Field exec = CoinbaseSourceTask.class.getDeclaredField("reconnectExecutor");
+        exec.setAccessible(true);
+        exec.set(realTask, java.util.concurrent.Executors.newSingleThreadScheduledExecutor());
+
+        realTask.stop();
+
+        // scheduleReconnect() after stop should not throw and should not enqueue work
+        // (the executor was shutdownNow'd). We just verify it returns cleanly.
+        realTask.scheduleReconnect();
+    }
 }


### PR DESCRIPTION
## Summary

Coinbase's public WebSocket periodically closes connections — every ~24h of uptime, or sooner if a network blip drops the socket. Before this patch, the SourceTask's listener just logged the error and dropped the connection; the task stayed `RUNNING` in Kafka Connect's view while `poll()` silently returned empty forever. Operators saw the connector green and the output topic flat at zero msg/s, with no symptom past the silent stall — workaround was `snctl kafka admin connect restart`.

## What changes

| | Before | After |
|---|---|---|
| `onClose` | (no handler) | logs + `scheduleReconnect()` |
| `onError` | logs only | logs + `scheduleReconnect()` |
| Reconnect schedule | n/a | 1s → 2s → 4s → 8s → 16s, capped at 30s, +25% jitter |
| Concurrency | n/a | `reconnectScheduled` AtomicBoolean dedupes simultaneous `onClose` + `onError` for the same drop |
| Backoff reset | n/a | `onOpen` resets counter so a long-lived connection that eventually drops gets a fast first retry |
| Async build failure (DNS/TLS) | `wsFuture.join()` blocks task thread | `whenComplete` feeds the failure back into the reconnect loop |
| `stop()` race | could re-enqueue against dead executor | flips `stopped` flag before teardown; `scheduleReconnect` short-circuits |
| `WebSocket` field | plain field | `AtomicReference<WebSocket>` (now read/written from listener thread, reconnect executor, and `stop()`) |
| `version()` | `1.1.0` | `1.1.1` |

## Test plan

- [x] `mvn -pl coinbase-kafka-connect-source clean package` → BUILD SUCCESS, **Tests run: 6, Failures: 0, Errors: 0**
- [x] New `scheduleReconnectIsNoOpAfterStop` test covers the race window between `stop()` and an in-flight listener firing `scheduleReconnect`.
- [x] Existing tests unchanged (`tickerFrameProducesKeyedRecord`, `heartbeatFrameIsDropped`, `frameWithoutProductIdIsDropped`, `baseSymbolHandlesEdgeCases`, `subscribeMessageSerializes`).
- [ ] Post-tag (v1.1.1): redeploy on `tradewise-demo`; force a drop (`iptables`-block the Coinbase WS endpoint for ~10s) and watch logs for `Coinbase WS closed ... scheduling reconnect` followed by `Coinbase WS open` without operator intervention.

## Release notes (for v1.1.1)

Same plugin shape, same `connector.class`, same config keys. No breaking changes — drop-in replacement for v1.1.0. The version constant in `CoinbaseSourceTask.version()` is bumped from `1.1.0` → `1.1.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
